### PR TITLE
Inclusão de medidor de tempo em milisegundos

### DIFF
--- a/test/multifovea.cpp
+++ b/test/multifovea.cpp
@@ -83,12 +83,18 @@ int main(int argc, char** argv){
   vector<KeyPoint> keypointSave;
   while(true){
     keypointSave.clear();
+    int64 t = cv::getTickCount();
     foveas.extractKeypoints(image, keypointSave);
+    t = cv::getTickCount() - t;
+    std::cout << "Feature extraction = " << t*1000/cv::getTickFrequency() << " milliseconds" << std::endl;
     
     // Computing descriptors
     SurfDescriptorExtractor extractor;
     Mat descriptors;
+    t = cv::getTickCount();
     extractor.compute(image, keypointSave, descriptors);
+    t = cv::getTickCount() - t;
+    std::cout << "Feature description = " << t*1000/cv::getTickFrequency() << " milliseconds" << std::endl;
     
     // Drawing the results
     Mat outputImg;


### PR DESCRIPTION
No arquivo multifovea foi inserido medidores de tempo com intuito
de avaliar a extração e a descripção das features em milisegundos
do sistema multifoveado.
